### PR TITLE
Save to DB fluorescence events

### DIFF
--- a/pvtrace/Trace.py
+++ b/pvtrace/Trace.py
@@ -858,7 +858,8 @@ class Tracer(object):
                             #print "IN"
                         
                         self.database.log(photon, surface_normal=photon.exit_device.shape.surface_normal(photon), on_surface_obj=photon.on_surface_object, surface_id=photon.exit_device.shape.surface_identifier(photon.position), ray_direction_bound=bound, emitter_material=photon.emitter_material, absorber_material=photon.absorber_material)
-                        
+                    else:
+                        self.database.log(photon)
                 else:
                     self.database.log(photon)
                 


### PR DESCRIPTION
This is needed otherwise from the data in the DB only is not possible to
recreate the full path of a given photon. E.g. when a fluorescent photon
is emitted, the location of the point where this happens is now recorded.