### PR TITLE
Example code to show the visualization error in nested cylinders

### DIFF
--- a/examples/nested_cylinders.py
+++ b/examples/nested_cylinders.py
@@ -1,0 +1,69 @@
+from pvtrace.geometry.cylinder import Cylinder
+from pvtrace.scene.node import Node
+from pvtrace.scene.scene import Scene
+from pvtrace.scene.renderer import MeshcatRenderer
+from pvtrace.geometry.sphere import Sphere
+from pvtrace.material.dielectric import Dielectric
+from pvtrace.light.light import Light
+from pvtrace.algorithm import photon_tracer
+import time
+import functools
+import numpy as np
+
+# Add nodes to the scene graph
+world = Node(
+    name="world (air)",
+    geometry=Sphere(
+        radius=10.0,
+        material=Dielectric.air()
+    )
+)
+cil1 = Node(
+    name="Cylinder1 (glass)",
+    geometry=Cylinder(
+        length=2,
+        radius=0.5,
+        material=Dielectric.glass()
+    ),
+    parent=world
+)
+cil1.translate((0, 0, 2))
+
+cil2 = Node(
+    name="Cylinder2 (glass)",
+    geometry=Cylinder(
+        length=2.5,
+        radius=0.4,
+        material=Dielectric.make_constant((300.0, 4000.0), 2)
+    ),
+    parent=cil1
+)
+
+# Add source of photons
+light = Node(
+    name="Light (555nm)",
+    light=Light(
+        divergence_delegate=functools.partial(
+            Light.cone_divergence, np.radians(20)
+        )
+    )
+)
+
+# Use meshcat to render the scene (optional)
+viewer = MeshcatRenderer(open_browser=True)
+scene = Scene(world)
+for ray in light.emit(100):
+    # Do something with the photon trace information...
+    info = photon_tracer.follow(ray, scene)
+    rays, events = zip(*info)
+    # Add rays to the renderer (optional)
+    viewer.add_ray_path(rays)
+# Open the scene in a new browser window (optional)
+viewer.render(scene)
+
+# Keep the script alive until Ctrl-C (optional)
+while True:
+    try:
+        time.sleep(0.1)
+    except KeyboardInterrupt:
+        break

--- a/examples/nested_cylinders.py
+++ b/examples/nested_cylinders.py
@@ -27,6 +27,7 @@ cil1 = Node(
     ),
     parent=world
 )
+cil1.rotate(np.radians(-90), [1, 0, 0])
 cil1.translate((0, 0, 2))
 
 cil2 = Node(

--- a/pvtrace/geometry/cylinder.py
+++ b/pvtrace/geometry/cylinder.py
@@ -1,6 +1,6 @@
 from pvtrace.geometry.geometry import Geometry
 from pvtrace.common.errors import GeometryError
-from pvtrace.geometry.utils import angle_between, norm, close_to_zero, ray_z_cylinder
+from pvtrace.geometry.utils import angle_between, norm, close_to_zero, ray_y_cylinder
 import numpy as np
 import logging
 logger = logging.getLogger(__name__)
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 class Cylinder(Geometry):
     """A cylinder defined by a length and radius with centre at (0, 0, 0) and aligned
-    along the z axis.
+    along the y axis.
     """
 
     def __init__(self, length, radius, material=None):
@@ -27,7 +27,7 @@ class Cylinder(Geometry):
         
     def is_on_surface(self, point):
         # Just use any direction for a fake ray, we only need the distance
-        _, dist = ray_z_cylinder(self.length, self.radius, point, norm((1,1,1)))
+        _, dist = ray_y_cylinder(self.length, self.radius, point, norm((1, 1, 1)))
         if len(dist) == 0:
             return False
         dist = dist[0]  # Only need closest intersection
@@ -38,26 +38,26 @@ class Cylinder(Geometry):
         return False
 
     def contains(self, point):
-        z = point[2]
-        r = np.sqrt(np.sum(np.array(point[:2])**2))
-        if z > -0.5 * self.length and z < 0.5 * self.length and r < self.radius:
+        y = point[1]
+        r = np.sqrt(np.sum(np.array(point[::2])**2))
+        if -0.5 * self.length < y < 0.5 * self.length and r < self.radius:
             return True
         return False
     
     def intersections(self, origin, direction):
-        points, _ = ray_z_cylinder(self.length, self.radius, origin, direction)
+        points, _ = ray_y_cylinder(self.length, self.radius, origin, direction)
         return points
 
     def normal(self, surface_point):
         """ Normal faces outwards by convention.
         """
-        z = surface_point[2]
-        if np.isclose(z, -0.5 * self.length):
-            return (0.0, 0.0, -1.0)
-        elif np.isclose(z, 0.5 * self.length):
-            return (0.0, 0.0, 1.0)
-        elif np.isclose(self.radius, np.sqrt(np.sum(np.array(surface_point[:2])**2))):
-            v = np.array(surface_point) - np.array([0.0, 0.0, surface_point[2]])
+        y = surface_point[1]
+        if np.isclose(y, -0.5 * self.length):
+            return (0.0, -1.0, 0.0)
+        elif np.isclose(y, 0.5 * self.length):
+            return (0.0, 1.0, 0.0)
+        elif np.isclose(self.radius, np.sqrt(np.sum(np.array(surface_point[::2])**2))):
+            v = np.array(surface_point) - np.array([0.0, surface_point[1], 0.0])
             n = tuple(norm(v).tolist())
             return n
         else:

--- a/pvtrace/geometry/utils.py
+++ b/pvtrace/geometry/utils.py
@@ -127,10 +127,10 @@ def aabb_intersection(min_point, max_point, ray_position, ray_direction):
     return tuple(hit_coordinates)
 
 
-def ray_z_cylinder(length, radius, ray_origin, ray_direction):
+def ray_y_cylinder(length, radius, ray_origin, ray_direction):
     """ Returns ray-cylinder intersection points for a cylinder aligned
         along the z-axis with centre at (0, 0, 0).
-        
+
         Parameters
         ----------
         length : float
@@ -141,21 +141,21 @@ def ray_z_cylinder(length, radius, ray_origin, ray_direction):
             The origin of the ray like, e.g. :math:`\left(0.0, 1.0, 2.0 \\right)`
         ray_direction : tuple of float
             The direction **unit** vector of the ray like, e.g. :math:`(n_x, n_y, n_z)`.
-        
+
         Returns
         -------
         points: tuple of points
-            Returns a tuple of tuple like ((0.0, 1.0, 2.0), ...) where each item is an 
+            Returns a tuple of tuple like ((0.0, 1.0, 2.0), ...) where each item is an
             intersection point. The tuple is sorted by distance from the ray origin.
-            
+
         Notes
         -----
-        
+
         Equation of ray is [1],
 
         :math:`P(t) = E + t`
 
-        where :math:`E` is the origin or "eye" point and :math:`D` is the direction vector. 
+        where :math:`E` is the origin or "eye" point and :math:`D` is the direction vector.
         In component form,
 
         .. math::
@@ -163,12 +163,12 @@ def ray_z_cylinder(length, radius, ray_origin, ray_direction):
             \\begin{bmatrix}
             x(t) \\
             y(t) \\
-            z(t) \\ 
-            \end{bmatrix} = 
+            z(t) \\
+            \end{bmatrix} =
             \\begin{bmatrix}
             x_E + t x_D \\
             y_E + t y_D \\
-            z_E + t z_D\\ 
+            z_E + t z_D\\
             \end{bmatrix}
 
         The equation of cylinder aligned along the z direction is,
@@ -176,45 +176,45 @@ def ray_z_cylinder(length, radius, ray_origin, ray_direction):
         .. math::
 
             x^2 + y^2 = R^2
-        
+
 
         where :math`R` is the radius of the cylinder.
 
         Substituting the equation of the ray into the equation of the cylinder,
 
         .. math::
-        
+
             (x_E + t x_D)^2 + (y_E + t y_D)^2 = R^2
 
         and after grouping the :math:`t^2` and :math:`t` terms,
 
         .. math::
-        
-            t^2\left(x_D^2 + y_D^2\\right) + 
-            t \left(2 x_E x_D + 2 y_E y _D \\right) + 
+
+            t^2\left(x_D^2 + y_D^2\\right) +
+            t \left(2 x_E x_D + 2 y_E y _D \\right) +
             \left( x_E^2 + y_E^2 - R^2 \\right) = 0
 
         which is a standard quadratic equation,
 
         .. math::
-            
+
             at^2 + bt + c = 0
 
-        Solution of this equation give two values :math:`\left( t_1, t_2 \\right)` which 
-        give the ray's distance to intersection points. To be ahead on the ray's path 
-        :math:`\left( t_1, t_2 \\right) >= 0` and to be real intersection points the 
-        values must be finite and have imaginary component of zero. 
+        Solution of this equation give two values :math:`\left( t_1, t_2 \\right)` which
+        give the ray's distance to intersection points. To be ahead on the ray's path
+        :math:`\left( t_1, t_2 \\right) >= 0` and to be real intersection points the
+        values must be finite and have imaginary component of zero.
 
-        The intersection with the cylinder caps is found by intersecting the ray with 
-        two infinite planes at :math:`z=0` and :math:`z=L`, where :math:`L` is the 
+        The intersection with the cylinder caps is found by intersecting the ray with
+        two infinite planes at :math:`z=0` and :math:`z=L`, where :math:`L` is the
         length of the cylinder. The ray-plane intersection is given by [2],
 
         .. math::
-        
+
             t = \\frac{(Q - P) \cdot n}{D \cdot n}
 
-        where :math:`t` is the distance from the ray origin to the intersection point, 
-        :math:`Q` is a point on the plane and :math:`n` the **outward** facing surface 
+        where :math:`t` is the distance from the ray origin to the intersection point,
+        :math:`Q` is a point on the plane and :math:`n` the **outward** facing surface
         normal at that point. As before :math:`P` is the origin of the ray and :math:`D`
         is the ray's direction unit vector.
 
@@ -222,84 +222,84 @@ def ray_z_cylinder(length, radius, ray_origin, ray_direction):
 
         .. math::
 
-            t_{\\text{bot}} = 
+            t_{\\text{bot}} =
             \\frac{
             \left(
                 \\begin{bmatrix}
                 0 \\
                 0 \\
-                -0.5 L \\ 
-                \end{bmatrix} - 
+                -0.5 L \\
+                \end{bmatrix} -
             \\begin{bmatrix}
                 x_E \\
                 y_E \\
-                z_E \\ 
+                z_E \\
             \end{bmatrix}
-            \\right) \cdot 
+            \\right) \cdot
             \\begin{bmatrix}
                 0 \\
                 0 \\
-                -1 \\ 
+                -1 \\
             \end{bmatrix}
             }{
             \\begin{bmatrix}
                 x_D \\
                 y_D \\
-                z_D \\ 
+                z_D \\
             \end{bmatrix} \cdot
             \\begin{bmatrix}
                 0 \\
                 0 \\
-                -1 \\ 
+                -1 \\
             \end{bmatrix}
             }
 
         and for the top cap at :math:`z=L`,
 
         .. math::
-            t_{\\text{bot}} = 
+            t_{\\text{bot}} =
             \\frac{
             \left(
                 \\begin{bmatrix}
                 0 \\
                 0 \\
-                0.5 L \\ 
-                \end{bmatrix} - 
+                0.5 L \\
+                \end{bmatrix} -
             \\begin{bmatrix}
                 x_E \\
                 y_E \\
-                z_E \\ 
+                z_E \\
             \end{bmatrix}
-            \\right) \cdot 
+            \\right) \cdot
             \\begin{bmatrix}
                 0 \\
                 0 \\
-                1 \\ 
+                1 \\
             \end{bmatrix}
             }{
             \\begin{bmatrix}
                 x_D \\
                 y_D \\
-                z_D \\ 
+                z_D \\
             \end{bmatrix} \cdot
             \\begin{bmatrix}
                 0 \\
                 0 \\
-                1 \\ 
+                1 \\
             \end{bmatrix}
             }
-    
+
 
         The intersection points with :math:`t<0` and points not contained inside the circle
-        of the end cap are rejected using :math:`(x^2 + y^2) < R`, where :math:`x` and 
+        of the end cap are rejected using :math:`(x^2 + y^2) < R`, where :math:`x` and
         :math:`y` are the components of the candidate intersection point.
-        
+
         References
         ----------
         [1] https://www.cl.cam.ac.uk/teaching/1999/AGraphHCI/
 
         [2] https://www.scratchapixel.com/lessons/3d-basic-rendering/minimal-ray-tracer-rendering-simple-shapes/ray-plane-and-ray-disk-intersection
-        
+
     """
     p0 = np.array(ray_origin)
     n0 = np.array(ray_direction)
@@ -307,30 +307,31 @@ def ray_z_cylinder(length, radius, ray_origin, ray_direction):
     xd, yd, zd = n0
 
     # Look for intersections on the cylinder surface
-    a = xd**2 + yd**2
-    b = 2 * (xe*xd + ye*yd)
-    c = xe**2 + ye**2 - radius**2
+    a = xd ** 2 + zd ** 2
+    b = 2 * (xe * xd + ze * zd)
+    c = xe ** 2 + ze ** 2 - radius ** 2
     tcyl = [t for t in np.roots([a, b, c]) if np.isfinite(t) and np.isreal(t) and t >= 0]
-        
+
     # Look for intersections on the cap surfaces
     with np.errstate(divide='ignore'):
         # top cap
-        point = np.array([0.0, 0.0, 0.5*length])
-        normal = np.array([0.0, 0.0, 1.0]) # outward facing at z = length
+        point = np.array([0.0, 0.5 * length, 0.0])
+        normal = np.array([0.0, 1.0, 0.0])  # outward facing at z = length
         ttopcap = (point - p0).dot(normal) / n0.dot(normal)
         # bottom cap
-        point = np.array([0.0, 0.0, -0.5*length])
-        normal = np.array([0.0, 0.0, -1.0]) # outward facing at z = 0
+        point = np.array([0.0, -0.5 * length, 0.0])
+        normal = np.array([0.0, -1.0, 0.0])  # outward facing at z = 0
         tbotcap = (point - p0).dot(normal) / n0.dot(normal)
         tcap = [t for t in (tbotcap, ttopcap) if np.isfinite(t) and t >= 0.0]
-    
+
     # Reject point cap points which are not in the cap's circle radius
     # and cylinder points which outside the length.
     cap_candidates = [(p0 + t * n0, t) for t in tcap]
     cap_candidates = [(point, t) for (point, t) in cap_candidates
-                      if np.sqrt(point[0]**2 + point[1]**2) < radius]
+                      if np.sqrt(point[0] ** 2 + point[2] ** 2) < radius]
     cyl_candidates = [(p0 + t * n0, t) for t in tcyl]
-    cyl_candidates = [(point, t) for (point, t) in cyl_candidates if point[2] > -0.5*length and point[2] < 0.5*length]
+    cyl_candidates = [(point, t) for (point, t) in cyl_candidates if
+                      point[1] > -0.5 * length and point[1] < 0.5 * length]
     intersection_info = tuple(cyl_candidates) + tuple(cap_candidates)
     intersection_info = sorted(intersection_info, key=lambda pair: pair[1])
     if len(intersection_info) == 0:
@@ -338,7 +339,6 @@ def ray_z_cylinder(length, radius, ray_origin, ray_direction):
     points = tuple([tuple(p.tolist()) for p in list(zip(*intersection_info))[0]])
     distances = tuple([float(d) for d in list(zip(*intersection_info))[1]])
     return points, distances
-
 
 # Equality tests
 

--- a/pvtrace/scene/renderer.py
+++ b/pvtrace/scene/renderer.py
@@ -65,11 +65,7 @@ class MeshcatRenderer(object):
             )
             # meshcat cylinder is aligned along y-axis. Align along z then apply the
             # node's transform as normal.
-            vis[pathname].set_transform(
-                transform.dot(
-                    tf.rotation_matrix(np.radians(-90), [1, 0, 0])
-                )
-            )
+            vis[pathname].set_transform(transform)
         elif isinstance(geometry, Mesh):
                 obj = meshcat.geometry.StlMeshGeometry.from_stream(
                     io.BytesIO(trimesh.exchange.stl.export_stl(geometry.trimesh))


### PR DESCRIPTION
Ray-tracing and visualization are not coherent one with the other.

See image below: the two cylinder share the same axis for the tracing algorithm, but not for the visualization
![Viz_error](https://user-images.githubusercontent.com/2422614/75350186-fa429a00-589d-11ea-850e-e5e20100bfd9.png)
