### PR TITLE
Add new component for "Reactor" and the associated Event.REACT

### DIFF
--- a/pvtrace/__init__.py
+++ b/pvtrace/__init__.py
@@ -35,7 +35,7 @@ from .light.event import Event
 
 
 # material
-from .material.component import Scatterer, Absorber, Luminophore
+from .material.component import Scatterer, Absorber, Luminophore, Reactor
 from .material.distribution import Distribution
 from .material.material import Material
 from .material.surface import (

--- a/pvtrace/algorithm/photon_tracer.py
+++ b/pvtrace/algorithm/photon_tracer.py
@@ -10,7 +10,7 @@ from pvtrace.scene.scene import Scene
 from pvtrace.scene.node import Node
 from pvtrace.light.ray import Ray
 from pvtrace.light.event import Event
-from pvtrace.material.component import Scatterer, Luminophore
+from pvtrace.material.component import Scatterer, Luminophore, Reactor
 from pvtrace.geometry.utils import (
     distance_between,
     close_to_zero,
@@ -184,7 +184,10 @@ def follow(scene, ray, maxsteps=1000, maxpathlength=np.inf, emit_method="kT"):
                 history.append((ray, event))
                 continue
             else:
-                history.append((ray, Event.ABSORB))
+                if isinstance(component, Reactor):
+                    history.append((ray, Event.REACT))
+                else:
+                    history.append((ray, Event.ABSORB))
                 break
         else:
             ray = ray.propagate(full_distance)

--- a/pvtrace/light/event.py
+++ b/pvtrace/light/event.py
@@ -13,3 +13,4 @@ class Event(Enum):
     EMIT = 5
     EXIT = 6
     KILL = 7
+    REACT = 8

--- a/pvtrace/material/component.py
+++ b/pvtrace/material/component.py
@@ -176,6 +176,47 @@ class Absorber(Scatterer):
         return False
 
 
+class Reactor(Absorber):
+    """Describes a reaction mixture: photon absorbed cause photochemical transformation.
+
+        Examples
+        --------
+        Create `Reactor` with isotropic and constant probability of scattering::
+
+            Reactor(1.0)
+    """
+
+    def __init__(self, coefficient, x=None, name="Reactor", hist=False):
+        """ coefficient: float, list, tuple or numpy.ndarray
+                Specifies the absorption coefficient per unit length. Constant values
+                can be supplied or a spectrum per nanometer per unit length.
+
+                If using a list of tuple you should also specify the wavelengths using
+                the `x` keyword.
+
+                If using a numpy array use `column_stack` to supply a single array with
+                a wavelength and coefficient values::
+
+            x: list, tuple of numpy.ndarray (optional)
+                Wavelength values in nanometers. Required when specifying a the
+                `coefficient` with an list or tuple.
+            name: str
+                A user-defined identifier string
+            hist: Bool
+                Specifies how the coefficient spectrum is sampled. If `True` the values
+                are treated as a histogram. If `False` the values are linearly
+                interpolated.
+
+        """
+
+        super(Reactor, self).__init__(
+            coefficient,
+            x=x,
+            hist=hist,
+            name=name,
+        )
+
+
 class Luminophore(Scatterer):
     """ Describes molecule, nanocrystal or material which absorbs and emits light.
 


### PR DESCRIPTION
The use of this component is to represent reaction mixtures in an LSC-PM[1]
device where the absorbed photons are used to drive a photochemical reaction.

This is essentially identical to Absorber but associated with a different event
to easily distinguish the different photon fates at the simulation end.

[1] See https://pure.tue.nl/ws/files/125461363/20190510_CO_Cambie_highres.pdf for details