### PR TITLE
Use logging instead print

### DIFF
--- a/pvtrace/cli/main.py
+++ b/pvtrace/cli/main.py
@@ -1,11 +1,13 @@
+import logging
 from pvtrace import MP_OPT
 
+logger = logging.getLogger(__name__)
 if MP_OPT == "pathos":
     try:
         import pathos
         from pathos.helpers import mp as multiprocessing
 
-        print("Using pathos")
+        logger.info("Using pathos")
     except ImportError:
         import multiprocessing
 
@@ -14,7 +16,7 @@ if MP_OPT == "pathos":
 if MP_OPT == "multiprocessing":
     import multiprocessing
 
-    print("Using multiprocessing")
+    logger.info("Using multiprocessing")
 
 import threading
 import typer

--- a/pvtrace/scene/scene.py
+++ b/pvtrace/scene/scene.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
-
+import logging
 from pvtrace import MP_OPT
 
+logger = logging.getLogger(__name__)
 if MP_OPT == "pathos":
     try:
         import pathos
         from pathos.helpers import mp as multiprocessing
 
-        print("Using pathos")
+        logger.info("Using pathos")
     except ImportError:
         import multiprocessing
 
@@ -16,7 +17,7 @@ if MP_OPT == "pathos":
 if MP_OPT == "multiprocessing":
     import multiprocessing
 
-    print("Using multiprocessing")
+    logger.info("Using multiprocessing")
 
 import os
 from typing import Optional, Sequence, Tuple, Union
@@ -275,7 +276,7 @@ class Scene(object):
         else:
             remainder = (num_rays_per_worker * workers) % num_rays
 
-        print(
+        logger.info(
             f"Simulating with {workers} workers with {num_rays_per_worker} ray per worker (with remainder {remainder})"
         )
         rays = [num_rays_per_worker] * workers


### PR DESCRIPTION
Transform print statement into logging messages so they can be turned off, e.g. when using a progress bar for a batch of simulation (see attached image)

![image](https://user-images.githubusercontent.com/2422614/106896796-55a61a80-66f2-11eb-870b-692b928be0a6.png)
