### PR TITLE
Move visualization properties from visualizer to Nodes 

### DIFF
--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -16,13 +16,13 @@ def make_hello_world_scene():
     )
     ball_lens = Node(
         name="ball-lens",
+        location=(0,0,2),
         geometry=Sphere(
             radius=1.0,
             material=Material(refractive_index=1.5),
         ),
         parent=world,
     )
-    ball_lens.location = (0, 0, 2)
 
     green_laser = Node(
         name="green-laser",

--- a/examples/hello_world_custom_appearances.yml
+++ b/examples/hello_world_custom_appearances.yml
@@ -12,12 +12,12 @@ nodes:
     sphere:
       radius: 1.0
       material:
-        color: 0x00ff00
-        reflectivity: 0
-        transparent: True
-        opacity: 0.5
-        visible: True
         refractive-index: 1.5
+    appearance:
+      color: 0x00ff00
+      visible: True
+      meshcat:
+        opacity: 0.5
 
   green-laser:
     location: [0, 0, 0]

--- a/examples/hello_world_custom_appearances.yml
+++ b/examples/hello_world_custom_appearances.yml
@@ -1,0 +1,28 @@
+version: "1.0"
+
+nodes:
+  world:
+    sphere:
+      radius: 10.0
+      material:
+        refractive-index: 1.0
+
+  ball-lens:
+    location: [0, 0, 2]
+    sphere:
+      radius: 1.0
+      material:
+        color: 0x00ff00
+        reflectivity: 0
+        transparent: True
+        opacity: 0.5
+        visible: True
+        refractive-index: 1.5
+
+  green-laser:
+    location: [0, 0, 0]
+    light:
+      mask:
+        direction:
+          cone:
+            half-angle: 22.5

--- a/examples/sphere_with_luminescent_dye.yml
+++ b/examples/sphere_with_luminescent_dye.yml
@@ -13,7 +13,6 @@ nodes:
       radius: 1.0
       material:
         refractive-index: 1.5
-        component: ["my-lumogen-dye", "my-absorber"]
 
   green-laser:
     location: [0, 0, 0]
@@ -28,7 +27,7 @@ components:
     luminophore:
       hist: true
       absorption:
-        coefficient: 50
+        coefficient: 5
         spectrum:
           name: lumogen-f-red-305
           range:
@@ -44,7 +43,3 @@ components:
             min: 500
             max: 1000
             spacing: 2
-  my-absorber:
-    absorber:
-      coefficient: 1
-      hist: true

--- a/examples/sphere_with_luminescent_dye.yml
+++ b/examples/sphere_with_luminescent_dye.yml
@@ -13,6 +13,7 @@ nodes:
       radius: 1.0
       material:
         refractive-index: 1.5
+        component: ["my-lumogen-dye"]
 
   green-laser:
     location: [0, 0, 0]
@@ -27,7 +28,7 @@ components:
     luminophore:
       hist: true
       absorption:
-        coefficient: 5
+        coefficient: 50
         spectrum:
           name: lumogen-f-red-305
           range:

--- a/examples/sphere_with_luminescent_dye.yml
+++ b/examples/sphere_with_luminescent_dye.yml
@@ -13,7 +13,7 @@ nodes:
       radius: 1.0
       material:
         refractive-index: 1.5
-        component: ["my-lumogen-dye"]
+        component: ["my-lumogen-dye", "my-absorber"]
 
   green-laser:
     location: [0, 0, 0]
@@ -44,3 +44,7 @@ components:
             min: 500
             max: 1000
             spacing: 2
+  my-absorber:
+    absorber:
+      coefficient: 1
+      hist: true

--- a/pvtrace/__init__.py
+++ b/pvtrace/__init__.py
@@ -50,3 +50,6 @@ from .material.utils import isotropic, henyey_greenstein, cone
 from .scene.node import Node
 from .scene.scene import Scene
 from .scene.renderer import MeshcatRenderer
+
+# cli
+from .cli.parse import parse

--- a/pvtrace/cli/main.py
+++ b/pvtrace/cli/main.py
@@ -8,7 +8,7 @@ import time as pytime
 from pathlib import Path
 from typing import Optional
 from queue import Empty
-from pvtrace.cli.parse import parse
+from pvtrace import parse
 from pvtrace.light.event import Event
 from pvtrace.scene.renderer import MeshcatRenderer
 from pvtrace.cli import count, spectrum, time

--- a/pvtrace/cli/parse.py
+++ b/pvtrace/cli/parse.py
@@ -99,7 +99,7 @@ def parse_v_1_0(spec: dict, working_directory: str) -> Scene:
         # Check that the declared components on the material have
         # actually been defined in the components section of the
         # file.
-        component_keys = spec.get("components", [])
+        component_keys = spec.get("component", [])
 
         for k in component_keys:
             if not (k in component_map):

--- a/pvtrace/cli/parse.py
+++ b/pvtrace/cli/parse.py
@@ -258,7 +258,7 @@ def parse_v_1_0(spec: dict, working_directory: str) -> Scene:
         if coefficient and (spectrum is not None):
             spectrum[:, 1] = spectrum[:, 1] / numpy.max(spectrum[:, 1]) * coefficient
             return Absorber(spectrum, name=name, hist=hist)
-        elif spectrum:
+        elif spectrum is not None:
             return Absorber(spectrum, name=name, hist=hist)
         elif coefficient:
             return Absorber(coefficient, name=name)
@@ -297,7 +297,7 @@ def parse_v_1_0(spec: dict, working_directory: str) -> Scene:
                 name=name,
                 hist=hist,
             )
-        elif spectrum:
+        elif spectrum is not None:
             return Scatterer(
                 spectrum,
                 quantum_yield=quantum_yield,

--- a/pvtrace/cli/parse.py
+++ b/pvtrace/cli/parse.py
@@ -99,7 +99,7 @@ def parse_v_1_0(spec: dict, working_directory: str) -> Scene:
         # Check that the declared components on the material have
         # actually been defined in the components section of the
         # file.
-        component_keys = spec.get("component", [])
+        component_keys = spec.get("components", [])
 
         for k in component_keys:
             if not (k in component_map):

--- a/pvtrace/cli/parse.py
+++ b/pvtrace/cli/parse.py
@@ -233,11 +233,14 @@ def parse_v_1_0(spec: dict, working_directory: str) -> Scene:
             filename = os.path.abspath(os.path.join(working_directory, filename))
             print(f"Reading {filename}")
 
-        df = pandas.read_csv(
-            filename,
-            usecols=[0, 1, 2],
-            index_col=0,
-        )
+        try:
+            df = pandas.read_csv(
+                filename,
+                usecols=[0, 1, 2],
+                index_col=0,
+            )
+        except FileNotFoundError as e:
+            raise AppError(f"Cannot find file {filename}!") from e
         # like numpy.column_stack((x, y))
         spectrum = df.iloc[:, 0:2].values
         return spectrum

--- a/pvtrace/cli/parse.py
+++ b/pvtrace/cli/parse.py
@@ -101,15 +101,15 @@ def parse_v_1_0(spec: dict, working_directory: str) -> Scene:
         # file.
         component_keys = []
         if "components" in spec:
-            component_keys = spec["components"]
+            component_keys = spec.pop("components")  # Remove PvTrace specific attribute to pass spec to Material init()
 
         for k in component_keys:
             if not (k in component_map):
                 raise ValueError(f"Missing {k} component")
 
-        refractive_index = spec["refractive-index"]
+        refractive_index = spec.pop("refractive-index")  # As per components
         components = [component_map[k] for k in component_keys]
-        material = Material(refractive_index=refractive_index, components=components)
+        material = Material(refractive_index=refractive_index, components=components, **spec)
         return material
 
     def parse_box(spec, component_map):
@@ -478,12 +478,14 @@ if __name__ == "__main__":
 
     def load_hello_world_scene():
         scene_spec = os.path.join(
-            os.path.dirname(os.path.realpath(__file__)), "hello_world.yml"
+            os.path.dirname(os.path.realpath(__file__)), "hello_world_custom_appearances.yml"
         )
         return parse(scene_spec)
 
-    renderer = MeshcatRenderer(
-        zmq_url="tcp://127.0.0.1:6000", open_browser=True, wireframe=True
+    renderer = MeshcatRenderer(open_browser=True, wireframe=True
     )
-    renderer.render(load_hello_world_scene())
-    IPython.embed()
+    scene = load_hello_world_scene()
+    renderer.render(scene)
+    input()
+    # IPython.embed()
+

--- a/pvtrace/cli/parse.py
+++ b/pvtrace/cli/parse.py
@@ -230,7 +230,7 @@ def parse_v_1_0(spec: dict, working_directory: str) -> Scene:
         # Get absolute path to the spectrum CSV
         if not os.path.isabs(filename):
             filename = os.path.abspath(os.path.join(working_directory, filename))
-            print(f"Reading {filename}")
+            # print(f"Reading {filename}")
 
         try:
             df = pandas.read_csv(
@@ -422,7 +422,7 @@ def parse_v_1_0(spec: dict, working_directory: str) -> Scene:
     component_specs = spec.get("components", None)
     if "components" in spec:
         for k, v in component_specs.items():
-            print(f"component: {k}")
+            # print(f"component: {k}")
             component_map[k] = parse_component(component_specs[k], k)
 
     coordinate_systems = dict()
@@ -431,7 +431,7 @@ def parse_v_1_0(spec: dict, working_directory: str) -> Scene:
     for k, v in node_specs.items():
 
         # YAML to node
-        print(f"node: {k}")
+        # print(f"node: {k}")
         nodes[k] = parse_node(v, k, component_map=component_map)
 
         # Capture additional information which can apply later

--- a/pvtrace/cli/parse.py
+++ b/pvtrace/cli/parse.py
@@ -362,7 +362,7 @@ def parse_v_1_0(spec: dict, working_directory: str) -> Scene:
                 name=name,
                 hist=hist,
             )
-        elif absorption_spectrum:
+        elif absorption_spectrum is not None:
             return Luminophore(
                 absorption_spectrum,
                 emission=emission_spectrum,

--- a/pvtrace/cli/parse.py
+++ b/pvtrace/cli/parse.py
@@ -14,6 +14,7 @@ import trimesh
 import numpy as np
 import pvtrace
 from typing import Callable, Tuple, List, Dict, Optional
+from pvtrace.common.errors import AppError
 from pvtrace import (
     Scene,
     Box,
@@ -258,7 +259,7 @@ def parse_v_1_0(spec: dict, working_directory: str) -> Scene:
         if coefficient and (spectrum is not None):
             spectrum[:, 1] = spectrum[:, 1] / numpy.max(spectrum[:, 1]) * coefficient
             return Absorber(spectrum, name=name, hist=hist)
-        elif spectrum:
+        elif spectrum is not None:
             return Absorber(spectrum, name=name, hist=hist)
         elif coefficient:
             return Absorber(coefficient, name=name)
@@ -297,7 +298,7 @@ def parse_v_1_0(spec: dict, working_directory: str) -> Scene:
                 name=name,
                 hist=hist,
             )
-        elif spectrum:
+        elif spectrum is not None:
             return Scatterer(
                 spectrum,
                 quantum_yield=quantum_yield,

--- a/pvtrace/cli/parse.py
+++ b/pvtrace/cli/parse.py
@@ -478,14 +478,12 @@ if __name__ == "__main__":
 
     def load_hello_world_scene():
         scene_spec = os.path.join(
-            os.path.dirname(os.path.realpath(__file__)), "hello_world_custom_appearances.yml"
+            os.path.dirname(os.path.realpath(__file__)), "hello_world.yml"
         )
         return parse(scene_spec)
 
-    renderer = MeshcatRenderer(open_browser=True, wireframe=True
+    renderer = MeshcatRenderer(
+        zmq_url="tcp://127.0.0.1:6000", open_browser=True, wireframe=True
     )
-    scene = load_hello_world_scene()
-    renderer.render(scene)
-    input()
-    # IPython.embed()
-
+    renderer.render(load_hello_world_scene())
+    IPython.embed()

--- a/pvtrace/cli/parse.py
+++ b/pvtrace/cli/parse.py
@@ -13,7 +13,7 @@ import os
 import trimesh
 import numpy as np
 import pvtrace
-from typing import Callable, Tuple, List, Dict, Optional
+from typing import Callable, Tuple, List, Dict, Optional, Union
 from pvtrace.common.errors import AppError
 from pvtrace import (
     Scene,
@@ -71,7 +71,7 @@ def load_spec(filename):
         return spec
 
 
-def parse(filename: str) -> Scene:
+def parse(filename: Union[str, bytes, os.PathLike]) -> Scene:
     schema = load_schema()
     spec = load_spec(filename)
     jsonschema.validate(spec, schema=schema)

--- a/pvtrace/cli/parse.py
+++ b/pvtrace/cli/parse.py
@@ -405,7 +405,7 @@ def parse_v_1_0(spec: dict, working_directory: str) -> Scene:
             "cylinder": parse_cylinder,
             "mesh": parse_mesh,
         }
-        appearance = spec.get("appearance", dict())
+        appearance = spec.get("appearance", {})
         for geometry_type in geometry_types:
             if geometry_type in spec:
                 geometry = geometry_mapper[geometry_type](

--- a/pvtrace/cli/parse.py
+++ b/pvtrace/cli/parse.py
@@ -99,17 +99,15 @@ def parse_v_1_0(spec: dict, working_directory: str) -> Scene:
         # Check that the declared components on the material have
         # actually been defined in the components section of the
         # file.
-        component_keys = []
-        if "components" in spec:
-            component_keys = spec.pop("components")  # Remove PvTrace specific attribute to pass spec to Material init()
+        component_keys = spec.get("components", [])
 
         for k in component_keys:
             if not (k in component_map):
                 raise ValueError(f"Missing {k} component")
 
-        refractive_index = spec.pop("refractive-index")  # As per components
+        refractive_index = spec["refractive-index"]
         components = [component_map[k] for k in component_keys]
-        material = Material(refractive_index=refractive_index, components=components, **spec)
+        material = Material(refractive_index=refractive_index, components=components)
         return material
 
     def parse_box(spec, component_map):
@@ -404,16 +402,17 @@ def parse_v_1_0(spec: dict, working_directory: str) -> Scene:
             "cylinder": parse_cylinder,
             "mesh": parse_mesh,
         }
+        appearance = spec.get("appearance", dict())
         for geometry_type in geometry_types:
             if geometry_type in spec:
                 geometry = geometry_mapper[geometry_type](
                     spec[geometry_type], component_map=component_map
                 )
-                return Node(geometry=geometry, name=name)
+                return Node(geometry=geometry, name=name, appearance=appearance)
 
         if "light" in spec:
             light = parse_light(spec["light"], name=name)
-            return Node(light=light, name=name)
+            return Node(light=light, name=name, appearance=appearance)
 
         raise ValueError()
 

--- a/pvtrace/cli/parse.py
+++ b/pvtrace/cli/parse.py
@@ -460,7 +460,6 @@ def parse_v_1_0(spec: dict, working_directory: str) -> Scene:
 
         direction = coordsys.get("direction", None)
         if direction:
-            print(f"Using direction {direction} for node {node}")
             node.look_at(direction)
 
     return Scene(nodes["world"])

--- a/pvtrace/cli/parse.py
+++ b/pvtrace/cli/parse.py
@@ -57,7 +57,6 @@ SPECTRUM_MODULES = {"lumogen-f-red-305": lumogen_f_red_305, "fluro-red": fluro_r
 
 
 def load_schema():
-    print(SCHEMA)
     with open(SCHEMA, "r") as fp:
         schema = json.load(fp)
         jsonschema.Draft7Validator.check_schema(schema)

--- a/pvtrace/cli/parse.py
+++ b/pvtrace/cli/parse.py
@@ -384,7 +384,6 @@ def parse_v_1_0(spec: dict, working_directory: str) -> Scene:
         raise ValueError("Unexpected luminophore format.")
 
     def parse_component(spec, name):
-        print(spec)
         if "absorber" in spec:
             return parse_absorber(spec["absorber"], name)
         elif "scatterer" in spec:

--- a/pvtrace/cli/pvtrace-schema-scene-spec.json
+++ b/pvtrace/cli/pvtrace-schema-scene-spec.json
@@ -219,7 +219,8 @@
                 "meshcat": {
                     "$ref": "#/definitions/meshcat"
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "meshcat": {
             "id": "#/definitions/meshcat",

--- a/pvtrace/cli/pvtrace-schema-scene-spec.json
+++ b/pvtrace/cli/pvtrace-schema-scene-spec.json
@@ -390,7 +390,8 @@
             "type": "object",
             "properties": {
                 "refractive-index": {
-                    "type": "number"
+                    "type": "number",
+                    "minimum": 1
                 },
                 "components": {
                     "type": "array",

--- a/pvtrace/cli/pvtrace-schema-scene-spec.json
+++ b/pvtrace/cli/pvtrace-schema-scene-spec.json
@@ -78,6 +78,9 @@
                 "light": {
                     "$ref": "#/definitions/light"
                 },
+                "appearance": {
+                    "$ref": "#/definitions/appearance"
+                },
                 "location": {
                     "type": "array",
                     "items": {
@@ -202,6 +205,49 @@
                     "$ref": "#/definitions/mask"
                 }
             }
+        },
+        "appearance": {
+            "id": "#/definitions/appearance",
+            "type": "object",
+            "properties": {
+                "color": {
+                    "type": "integer"
+                },
+                "visible": {
+                    "type": "boolean"
+                },
+                "meshcat": {
+                    "$ref": "#/definitions/meshcat"
+                }
+            }
+        },
+        "meshcat": {
+            "id": "#/definitions/meshcat",
+            "type": "object",
+            "properties": {
+                "opacity": {
+                    "type": "number"
+                },
+                "wireframe": {
+                    "type": "boolean"
+                },
+                "reflectivity": {
+                    "type": "number"
+                },
+                "side": {
+                    "type": "integer"
+                },
+                "linewidth": {
+                    "type": "number"
+                },
+                "wireframeLinewidth": {
+                    "type": "number"
+                },
+                "vertexColors": {
+                    "type": "number"
+                }
+            },
+            "additionalProperties": true
         },
         "mask": {
             "id": "#/definitions/mask",

--- a/pvtrace/cli/pvtrace-schema-scene-spec.json
+++ b/pvtrace/cli/pvtrace-schema-scene-spec.json
@@ -390,14 +390,34 @@
             "type": "object",
             "properties": {
                 "refractive-index": {
-                    "type": "number",
-                    "minimum": 1
+                    "type": "number"
                 },
                 "components": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
+                },
+                "color": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 16777215
+                },
+                "reflectivity": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "transparent": {
+                    "type": "boolean"
+                },
+                "opacity": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "visible": {
+                    "type": "boolean"
                 }
             },
             "required": [

--- a/pvtrace/cli/pvtrace-schema-scene-spec.json
+++ b/pvtrace/cli/pvtrace-schema-scene-spec.json
@@ -465,6 +465,9 @@
                 "absorber": {
                     "$ref": "#/definitions/absorber"
                 },
+                "reactor": {
+                    "$ref": "#/definitions/reactor"
+                },
                 "builtin": {
                     "description": "Name of build in component",
                     "type": "string"
@@ -484,6 +487,11 @@
                 {
                     "required": [
                         "absorber"
+                    ]
+                },
+                {
+                    "required": [
+                        "reactor"
                     ]
                 }
             ],
@@ -565,6 +573,40 @@
             ]
         },
         "absorber": {
+            "type": "object",
+            "properties": {
+                "coefficient": {
+                    "type": "number",
+                    "minimum": 0
+                },
+                "hist": {
+                    "type": "boolean"
+                },
+                "spectrum": {
+                    "$ref": "#/definitions/spectrum"
+                }
+            },
+            "additionalProperties": false,
+            "anyOf": [
+                {
+                    "required": [
+                        "coefficient"
+                    ]
+                },
+                {
+                    "required": [
+                        "spectrum"
+                    ]
+                },
+                {
+                    "required": [
+                        "coefficient",
+                        "spectrum"
+                    ]
+                }
+            ]
+        },
+        "reactor": {
             "type": "object",
             "properties": {
                 "coefficient": {

--- a/pvtrace/cli/pvtrace-schema-scene-spec.json
+++ b/pvtrace/cli/pvtrace-schema-scene-spec.json
@@ -398,27 +398,6 @@
                     "items": {
                         "type": "string"
                     }
-                },
-                "color": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 16777215
-                },
-                "reflectivity": {
-                    "type": "number",
-                    "minimum": 0,
-                    "maximum": 1
-                },
-                "transparent": {
-                    "type": "boolean"
-                },
-                "opacity": {
-                    "type": "number",
-                    "minimum": 0,
-                    "maximum": 1
-                },
-                "visible": {
-                    "type": "boolean"
                 }
             },
             "required": [

--- a/pvtrace/geometry/cylinder.py
+++ b/pvtrace/geometry/cylinder.py
@@ -23,7 +23,7 @@ class Cylinder(Geometry):
         return self._material
 
     @material.setter
-    def set_material(self, new_value):
+    def material(self, new_value):
         self._material = new_value
 
     def is_on_surface(self, point):

--- a/pvtrace/geometry/sphere.py
+++ b/pvtrace/geometry/sphere.py
@@ -21,7 +21,7 @@ class Sphere(Geometry):
         return self._material
 
     @material.setter
-    def set_material(self, new_value):
+    def material(self, new_value):
         self._material = new_value
 
     def is_on_surface(self, point):

--- a/pvtrace/material/component.py
+++ b/pvtrace/material/component.py
@@ -107,7 +107,7 @@ class Scatterer(Component):
         self._coefficient = coefficient
         if coefficient is None:
             raise ValueError("Coefficient must be specified.")
-        elif isinstance(coefficient, (float, np.float)):
+        elif isinstance(coefficient, (float, np.float, int)):
             self._abs_dist = Distribution(x=None, y=coefficient, hist=hist)
         elif isinstance(coefficient, np.ndarray):
             self._abs_dist = Distribution(

--- a/pvtrace/material/component.py
+++ b/pvtrace/material/component.py
@@ -107,7 +107,7 @@ class Scatterer(Component):
         self._coefficient = coefficient
         if coefficient is None:
             raise ValueError("Coefficient must be specified.")
-        elif isinstance(coefficient, (float, np.float, int)):
+        elif isinstance(coefficient, (float, np.number, int)):
             self._abs_dist = Distribution(x=None, y=coefficient, hist=hist)
         elif isinstance(coefficient, np.ndarray):
             self._abs_dist = Distribution(

--- a/pvtrace/material/distribution.py
+++ b/pvtrace/material/distribution.py
@@ -29,7 +29,7 @@ class Distribution(object):
                 If x is not ascending or if any element of y is not finite.
         """
         self.hist = hist
-        if x is None and isinstance(y, (float, np.float, int)):
+        if x is None and isinstance(y, (float, np.number, int)):
             self._x = None
             self._y = y
         else:
@@ -70,7 +70,7 @@ class Distribution(object):
             ValueError
                 If x is outside the data range.
         """
-        if self._x is None and isinstance(self._y, (float, np.float, int)):
+        if self._x is None and isinstance(self._y, (float, np.number, int)):
             if isinstance(x, (list, tuple, np.ndarray)):
                 return np.zeros(len(x)) + self._y
             else:

--- a/pvtrace/material/distribution.py
+++ b/pvtrace/material/distribution.py
@@ -29,7 +29,7 @@ class Distribution(object):
                 If x is not ascending or if any element of y is not finite.
         """
         self.hist = hist
-        if x is None and isinstance(y, (float, np.float)):
+        if x is None and isinstance(y, (float, np.float, int)):
             self._x = None
             self._y = y
         else:
@@ -70,7 +70,7 @@ class Distribution(object):
             ValueError
                 If x is outside the data range.
         """
-        if self._x is None and isinstance(self._y, (float, np.float)):
+        if self._x is None and isinstance(self._y, (float, np.float, int)):
             if isinstance(x, (list, tuple, np.ndarray)):
                 return np.zeros(len(x)) + self._y
             else:

--- a/pvtrace/material/material.py
+++ b/pvtrace/material/material.py
@@ -8,10 +8,6 @@ logger = logging.getLogger(__name__)
 
 
 class Material:
-    """
-    Material representation. This include the PvTrace-specific properties (refractive index, absorption components) as
-    well as the visualization properties used to visualize the object from the meshcat.geometry MeshBasicMaterial class.
-    """
     def __init__(self, refractive_index: float, surface=None, components=None):
         self.refractive_index = refractive_index
         self.surface = Surface() if surface is None else surface

--- a/pvtrace/material/material.py
+++ b/pvtrace/material/material.py
@@ -2,19 +2,17 @@ from typing import Tuple
 import numpy as np
 from pvtrace.material.component import Component
 from pvtrace.material.surface import Surface
-import meshcat.geometry as g
 import logging
 
 logger = logging.getLogger(__name__)
 
 
-class Material(g.MeshBasicMaterial):
+class Material:
     """
     Material representation. This include the PvTrace-specific properties (refractive index, absorption components) as
     well as the visualization properties used to visualize the object from the meshcat.geometry MeshBasicMaterial class.
     """
-    def __init__(self, refractive_index: float, surface=None, components=None, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, refractive_index: float, surface=None, components=None):
         self.refractive_index = refractive_index
         self.surface = Surface() if surface is None else surface
         self.components = [] if components is None else components

--- a/pvtrace/material/material.py
+++ b/pvtrace/material/material.py
@@ -2,13 +2,19 @@ from typing import Tuple
 import numpy as np
 from pvtrace.material.component import Component
 from pvtrace.material.surface import Surface
+import meshcat.geometry as g
 import logging
 
 logger = logging.getLogger(__name__)
 
 
-class Material(object):
-    def __init__(self, refractive_index: float, surface=None, components=None):
+class Material(g.MeshBasicMaterial):
+    """
+    Material representation. This include the PvTrace-specific properties (refractive index, absorption components) as
+    well as the visualization properties used to visualize the object from the meshcat.geometry MeshBasicMaterial class.
+    """
+    def __init__(self, refractive_index: float, surface=None, components=None, **kwargs):
+        super().__init__(**kwargs)
         self.refractive_index = refractive_index
         self.surface = Surface() if surface is None else surface
         self.components = [] if components is None else components

--- a/pvtrace/scene/node.py
+++ b/pvtrace/scene/node.py
@@ -18,13 +18,17 @@ class Node(NodeMixin, Transformable):
     """
 
     def __init__(
-        self, name=None, parent=None, location=None, geometry=None, light=None
+        self, name=None, parent=None, location=None, geometry=None, light=None, appearance=None
     ):
         super(Node, self).__init__(location=location)
         self.name = name
         self.parent = parent
         self.geometry = geometry
         self.light = light
+        if appearance:
+            self.appearance = appearance
+        else:
+            self.appearance = dict()
 
     def __repr__(self):
         return "Node({})".format(self.name)

--- a/pvtrace/scene/node.py
+++ b/pvtrace/scene/node.py
@@ -25,7 +25,7 @@ class Node(NodeMixin, Transformable):
         self.parent = parent
         self.geometry = geometry
         self.light = light
-        self.appearance = appearance if appearance else dict()
+        self.appearance = appearance if appearance else {}
 
     def __repr__(self):
         return "Node({})".format(self.name)

--- a/pvtrace/scene/node.py
+++ b/pvtrace/scene/node.py
@@ -38,7 +38,7 @@ class Node(NodeMixin, Transformable):
         The "face" of the node is defined to be direction [0, 0, 1]. This method
         with always point the face of the node along the direction vector
         specified. Note that the if the node is displaced from the origin this
-        will be respected and the node will be rotate around it's centre.
+        will be respected and the node will be rotate around its centre.
 
         References
         ----------

--- a/pvtrace/scene/node.py
+++ b/pvtrace/scene/node.py
@@ -25,10 +25,7 @@ class Node(NodeMixin, Transformable):
         self.parent = parent
         self.geometry = geometry
         self.light = light
-        if appearance:
-            self.appearance = appearance
-        else:
-            self.appearance = dict()
+        self.appearance = appearance if appearance else dict()
 
     def __repr__(self):
         return "Node({})".format(self.name)

--- a/pvtrace/scene/renderer.py
+++ b/pvtrace/scene/renderer.py
@@ -29,10 +29,10 @@ class MeshcatRenderer(object):
         zmq_url=None,
         max_histories=10,
         open_browser=False,
-        wireframe=False,
-        transparency=True,
-        opacity=0.5,
-        reflectivity=1.0,
+        wireframe: bool = None,
+        transparency: bool = True,
+        opacity: float = 0.5,
+        reflectivity: float = 1.0,
     ):
         super(MeshcatRenderer, self).__init__()
         self.vis = meshcat.Visualizer(zmq_url=zmq_url)
@@ -41,6 +41,8 @@ class MeshcatRenderer(object):
         self.ray_histories = deque(maxlen=max_histories)
         self.max_histories = max_histories
         self.added_index = 0
+
+        # If set these properties will overwrite any material-level attribute
         self.wireframe = wireframe
         self.transparency = transparency
         self.opacity = opacity
@@ -67,11 +69,15 @@ class MeshcatRenderer(object):
 
     def add_geometry(self, geometry, pathname, transform):
         vis = self.vis
-        material = g.MeshBasicMaterial(
-            reflectivity=self.reflectivity, sides=0, wireframe=self.wireframe
-        )
-        material.transparency = self.transparency
-        material.opacity = self.opacity
+        material = geometry.material
+        if self.wireframe is not None:
+            material.wireframe = self.wireframe
+        if self.transparency is not None:
+            material.transparency = self.transparency
+        if self.opacity is not None:
+            material.opacity = self.opacity
+        if self.reflectivity is not None:
+            material.reflectivity = self.reflectivity
 
         if isinstance(geometry, Sphere):
             sphere = geometry

--- a/pvtrace/scene/renderer.py
+++ b/pvtrace/scene/renderer.py
@@ -42,7 +42,7 @@ class MeshcatRenderer(object):
         self.max_histories = max_histories
         self.added_index = 0
 
-        # If set these properties will overwrite any material-level attribute
+        # If set these properties will overwrite any node-level attribute
         self.wireframe = wireframe
         self.transparency = transparency
         self.opacity = opacity

--- a/pvtrace/scene/renderer.py
+++ b/pvtrace/scene/renderer.py
@@ -62,22 +62,29 @@ class MeshcatRenderer(object):
         # you would get that behaviour.
         pathname = " | ".join([x.name for x in node.path])
         if node.geometry is not None:
+            # TODO: add common material properties (color etc) and meshcat specific ones, if present.
+            # e.g.
+            if "color" in node.appearance:
+                ...
+
+            if "meshcat" in node.appearance:
+                meshcat_properties = node.appearance["meshcat"]
+            else:
+                meshcat_properties = dict()
+            # Preparing material
+            material = g.MeshBasicMaterial(
+                reflectivity=self.reflectivity, sides=0, wireframe=self.wireframe, **meshcat_properties
+            )
+            material.transparency = self.transparency
+            material.opacity = self.opacity
+
             # Transforming everything to global
             self.add_geometry(
-                node.geometry, pathname, node.transformation_to(node.root)
+                node.geometry, pathname, node.transformation_to(node.root), material
             )
 
-    def add_geometry(self, geometry, pathname, transform):
+    def add_geometry(self, geometry, pathname, transform, material):
         vis = self.vis
-        material = geometry.material
-        if self.wireframe is not None:
-            material.wireframe = self.wireframe
-        if self.transparency is not None:
-            material.transparency = self.transparency
-        if self.opacity is not None:
-            material.opacity = self.opacity
-        if self.reflectivity is not None:
-            material.reflectivity = self.reflectivity
 
         if isinstance(geometry, Sphere):
             sphere = geometry

--- a/pvtrace/scene/renderer.py
+++ b/pvtrace/scene/renderer.py
@@ -62,21 +62,29 @@ class MeshcatRenderer(object):
         # you would get that behaviour.
         pathname = " | ".join([x.name for x in node.path])
         if node.geometry is not None:
-            # TODO: add common material properties (color etc) and meshcat specific ones, if present.
-            # e.g.
-            if "color" in node.appearance:
-                ...
+            # Color: int
+            color = node.appearance.get("color", 0xffffff)  # Default is white
+            assert 0x000000 <= color <= 0xffffff
 
-            if "meshcat" in node.appearance:
-                meshcat_properties = node.appearance["meshcat"]
-            else:
-                meshcat_properties = dict()
+            # Visible: bool
+            visible = node.appearance.get("visible", True)
+
+            # Additional meshcat properties
+            meshcat_properties = node.appearance.get("meshcat", {})
+
             # Preparing material
             material = g.MeshBasicMaterial(
-                reflectivity=self.reflectivity, sides=0, wireframe=self.wireframe, **meshcat_properties
+                color=color, visible=visible, **meshcat_properties
             )
-            material.transparency = self.transparency
-            material.opacity = self.opacity
+            # Overwrite node settings with renderer ones if set
+            if self.reflectivity:
+                material.reflectivity = self.reflectivity
+            if self.wireframe:
+                material.wireframe = self.wireframe
+            if self.opacity:
+                material.opacity = self.opacity
+            if self.transparency:
+                material.transparency = self.transparency
 
             # Transforming everything to global
             self.add_geometry(

--- a/pvtrace/scene/renderer.py
+++ b/pvtrace/scene/renderer.py
@@ -29,10 +29,10 @@ class MeshcatRenderer(object):
         zmq_url=None,
         max_histories=10,
         open_browser=False,
-        wireframe: bool = None,
-        transparency: bool = True,
-        opacity: float = 0.5,
-        reflectivity: float = 1.0,
+        wireframe=False,
+        transparency=True,
+        opacity=0.5,
+        reflectivity=1.0,
     ):
         super(MeshcatRenderer, self).__init__()
         self.vis = meshcat.Visualizer(zmq_url=zmq_url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ meshcat>=0.0.16
 numpy
 pandas
 trimesh[easy]
+typer
+asciiplotlib

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,6 +2,8 @@ anytree
 meshcat>=0.0.16
 numpy
 trimesh[easy]
+typer
+asciiplotlib
 jupyter
 matplotlib
 pandas

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     package_data={"": ["*.json", "schema.sql"]},
     include_package_data=True,
     keywords=["optics", "raytracing", "photovoltaics", "energy"],
-    install_requires=["numpy", "pandas", "anytree", "meshcat>=0.0.16", "trimesh[easy]"],
+    install_requires=["numpy", "pandas", "anytree", "meshcat>=0.0.16", "trimesh[easy]", "typer", "asciiplotlib"],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     entry_points={"console_scripts": ["pvtrace-cli=pvtrace.cli.main:main"]},
     python_requires=">=3.7.2,<3.8",
     packages=find_packages(),
-    package_data={"": ["*.json"]},
+    package_data={"": ["*.json", "schema.sql"]},
     include_package_data=True,
     keywords=["optics", "raytracing", "photovoltaics", "energy"],
     install_requires=["numpy", "pandas", "anytree", "meshcat>=0.0.16", "trimesh[easy]"],

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ setup(
     entry_points={"console_scripts": ["pvtrace-cli=pvtrace.cli.main:main"]},
     python_requires=">=3.7.2,<3.8",
     packages=find_packages(),
+    package_data={"": ["*.json"]},
+    include_package_data=True,
     keywords=["optics", "raytracing", "photovoltaics", "energy"],
     install_requires=["numpy", "pandas", "anytree", "meshcat>=0.0.16", "trimesh[easy]"],
     classifiers=[

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,7 @@ LSC_EXAMPLE_YML = os.path.abspath(os.path.join(HERE, "data", "lsc_scene.yml"))
 from tests.data.lsc_scene import scene as py_lsc_scene, green_laser as py_light_node
 
 HELLO_WORLD_YML = os.path.abspath(os.path.join(EXAMPLES, "hello_world.yml"))
+HELLO_WORLD_YML_CUSTOM_APPEARANCES = os.path.abspath(os.path.join(EXAMPLES, "hello_world_custom_appearances.yml"))
 
 
 @pytest.fixture(scope="session")
@@ -71,6 +72,10 @@ def test_parse_full_example_yml():
 
 def test_parse_hello_world_yml():
     assert isinstance(parse(HELLO_WORLD_YML), Scene)
+
+
+def test_parse_hello_world_yml_custom_appearances():
+    assert isinstance(parse(HELLO_WORLD_YML_CUSTOM_APPEARANCES), Scene)
 
 
 def test_equality_by_tracing():


### PR DESCRIPTION
For many PvTrace simulation it would be nice to be able to add node visualization properties,
such as color transparency etc.
However, currently, the only visualization options (wireframe, transparency, opacity and reflectivity)
are attributes of MeshcatRenderer and apply in the same way to all the scene objects.

This can be modified at runtime *by setting the corresponding Meshcat material attributes)
but there is currently no way to save the visualization options in the scene definition (e.g. in
the YML file)

This commit allows for more granular control on the visual appearances of the scene, when rendered.
At the same time, the old global switches at the MeshcatRenderer are kept and are given priority as,
e.g. it may be needed/necessary/useful to show all scene nodes as wireframe for debugging purposes.