### PR TITLE
Remove deprecated use of np.float and np.int

### DIFF
--- a/pvtrace/cli/parse.py
+++ b/pvtrace/cli/parse.py
@@ -238,6 +238,7 @@ def parse_v_1_0(spec: dict, working_directory: str) -> Scene:
             filename,
             usecols=[0, 1, 2],
             index_col=0,
+            dtype=np.float64
         )
         # like numpy.column_stack((x, y))
         spectrum = df.iloc[:, 0:2].values

--- a/pvtrace/geometry/transformable.py
+++ b/pvtrace/geometry/transformable.py
@@ -46,7 +46,7 @@ class Transformable(object):
         """
         super(Transformable, self).__init__()
         self._location = (
-            np.zeros(3, dtype=np.float) if location is None else np.array(location)
+            np.zeros(3, dtype=float) if location is None else np.array(location)
         )
         self._pose = translation_matrix(self._location)
 

--- a/pvtrace/geometry/utils.py
+++ b/pvtrace/geometry/utils.py
@@ -139,7 +139,7 @@ def ray_z_cylinder(length, radius, ray_origin, ray_direction):
         radius : float
             The radius of the cylinder
         ray_origin : tuple of float
-            The origin of the ray like, e.g. :math:`\left(0.0, 1.0, 2.0 \\right)`
+            The origin of the ray like, e.g. :math:`\\left(0.0, 1.0, 2.0 \\right)`
         ray_direction : tuple of float
             The direction **unit** vector of the ray like, e.g. :math:`(n_x, n_y, n_z)`.
         
@@ -165,12 +165,12 @@ def ray_z_cylinder(length, radius, ray_origin, ray_direction):
             x(t) \\
             y(t) \\
             z(t) \\ 
-            \end{bmatrix} = 
+            \\end{bmatrix} =
             \\begin{bmatrix}
             x_E + t x_D \\
             y_E + t y_D \\
             z_E + t z_D\\ 
-            \end{bmatrix}
+            \\end{bmatrix}
 
         The equation of cylinder aligned along the z direction is,
 
@@ -191,9 +191,9 @@ def ray_z_cylinder(length, radius, ray_origin, ray_direction):
 
         .. math::
         
-            t^2\left(x_D^2 + y_D^2\\right) + 
-            t \left(2 x_E x_D + 2 y_E y _D \\right) + 
-            \left( x_E^2 + y_E^2 - R^2 \\right) = 0
+            t^2\\left(x_D^2 + y_D^2\\right) +
+            t \\left(2 x_E x_D + 2 y_E y _D \\right) +
+            \\left( x_E^2 + y_E^2 - R^2 \\right) = 0
 
         which is a standard quadratic equation,
 
@@ -201,9 +201,9 @@ def ray_z_cylinder(length, radius, ray_origin, ray_direction):
             
             at^2 + bt + c = 0
 
-        Solution of this equation give two values :math:`\left( t_1, t_2 \\right)` which 
+        Solution of this equation give two values :math:`\\left( t_1, t_2 \\right)` which
         give the ray's distance to intersection points. To be ahead on the ray's path 
-        :math:`\left( t_1, t_2 \\right) >= 0` and to be real intersection points the 
+        :math:`\\left( t_1, t_2 \\right) >= 0` and to be real intersection points the
         values must be finite and have imaginary component of zero. 
 
         The intersection with the cylinder caps is found by intersecting the ray with 
@@ -212,7 +212,7 @@ def ray_z_cylinder(length, radius, ray_origin, ray_direction):
 
         .. math::
         
-            t = \\frac{(Q - P) \cdot n}{D \cdot n}
+            t = \\frac{(Q - P) \\cdot n}{D \\cdot n}
 
         where :math:`t` is the distance from the ray origin to the intersection point, 
         :math:`Q` is a point on the plane and :math:`n` the **outward** facing surface 
@@ -225,34 +225,34 @@ def ray_z_cylinder(length, radius, ray_origin, ray_direction):
 
             t_{\\text{bot}} = 
             \\frac{
-            \left(
+            \\left(
                 \\begin{bmatrix}
                 0 \\
                 0 \\
                 -0.5 L \\ 
-                \end{bmatrix} - 
+                \\end{bmatrix} -
             \\begin{bmatrix}
                 x_E \\
                 y_E \\
                 z_E \\ 
-            \end{bmatrix}
-            \\right) \cdot 
+            \\end{bmatrix}
+            \\right) \\cdot
             \\begin{bmatrix}
                 0 \\
                 0 \\
                 -1 \\ 
-            \end{bmatrix}
+            \\end{bmatrix}
             }{
             \\begin{bmatrix}
                 x_D \\
                 y_D \\
                 z_D \\ 
-            \end{bmatrix} \cdot
+            \\end{bmatrix} \\cdot
             \\begin{bmatrix}
                 0 \\
                 0 \\
                 -1 \\ 
-            \end{bmatrix}
+            \\end{bmatrix}
             }
 
         and for the top cap at :math:`z=L`,
@@ -260,34 +260,34 @@ def ray_z_cylinder(length, radius, ray_origin, ray_direction):
         .. math::
             t_{\\text{bot}} = 
             \\frac{
-            \left(
+            \\left(
                 \\begin{bmatrix}
                 0 \\
                 0 \\
                 0.5 L \\ 
-                \end{bmatrix} - 
+                \\end{bmatrix} -
             \\begin{bmatrix}
                 x_E \\
                 y_E \\
                 z_E \\ 
-            \end{bmatrix}
-            \\right) \cdot 
+            \\end{bmatrix}
+            \\right) \\cdot
             \\begin{bmatrix}
                 0 \\
                 0 \\
                 1 \\ 
-            \end{bmatrix}
+            \\end{bmatrix}
             }{
             \\begin{bmatrix}
                 x_D \\
                 y_D \\
                 z_D \\ 
-            \end{bmatrix} \cdot
+            \\end{bmatrix} \\cdot
             \\begin{bmatrix}
                 0 \\
                 0 \\
                 1 \\ 
-            \end{bmatrix}
+            \\end{bmatrix}
             }
     
 
@@ -376,7 +376,7 @@ def allinrange(x, x_range):
         x_range : tuple of float
             A tuple defining a range like (xmin, xmax)
     """
-    if isinstance(x, (int, float, np.float, np.int)):
+    if isinstance(x, (int, float)):
         x = np.array([x])
     return np.where(np.logical_or(x < x_range[0], x > x_range[1]))[0].size == 0
 

--- a/pvtrace/geometry/utils.py
+++ b/pvtrace/geometry/utils.py
@@ -139,7 +139,7 @@ def ray_z_cylinder(length, radius, ray_origin, ray_direction):
         radius : float
             The radius of the cylinder
         ray_origin : tuple of float
-            The origin of the ray like, e.g. :math:`\\left(0.0, 1.0, 2.0 \\right)`
+            The origin of the ray like, e.g. :math:`\left(0.0, 1.0, 2.0 \\right)`
         ray_direction : tuple of float
             The direction **unit** vector of the ray like, e.g. :math:`(n_x, n_y, n_z)`.
         
@@ -165,12 +165,12 @@ def ray_z_cylinder(length, radius, ray_origin, ray_direction):
             x(t) \\
             y(t) \\
             z(t) \\ 
-            \\end{bmatrix} =
+            \end{bmatrix} =
             \\begin{bmatrix}
             x_E + t x_D \\
             y_E + t y_D \\
             z_E + t z_D\\ 
-            \\end{bmatrix}
+            \end{bmatrix}
 
         The equation of cylinder aligned along the z direction is,
 
@@ -191,9 +191,9 @@ def ray_z_cylinder(length, radius, ray_origin, ray_direction):
 
         .. math::
         
-            t^2\\left(x_D^2 + y_D^2\\right) +
-            t \\left(2 x_E x_D + 2 y_E y _D \\right) +
-            \\left( x_E^2 + y_E^2 - R^2 \\right) = 0
+            t^2\left(x_D^2 + y_D^2\\right) +
+            t \left(2 x_E x_D + 2 y_E y _D \\right) +
+            \left( x_E^2 + y_E^2 - R^2 \\right) = 0
 
         which is a standard quadratic equation,
 
@@ -201,9 +201,9 @@ def ray_z_cylinder(length, radius, ray_origin, ray_direction):
             
             at^2 + bt + c = 0
 
-        Solution of this equation give two values :math:`\\left( t_1, t_2 \\right)` which
+        Solution of this equation give two values :math:`\left( t_1, t_2 \\right)` which
         give the ray's distance to intersection points. To be ahead on the ray's path 
-        :math:`\\left( t_1, t_2 \\right) >= 0` and to be real intersection points the
+        :math:`\left( t_1, t_2 \\right) >= 0` and to be real intersection points the
         values must be finite and have imaginary component of zero. 
 
         The intersection with the cylinder caps is found by intersecting the ray with 
@@ -212,7 +212,7 @@ def ray_z_cylinder(length, radius, ray_origin, ray_direction):
 
         .. math::
         
-            t = \\frac{(Q - P) \\cdot n}{D \\cdot n}
+            t = \\frac{(Q - P) \cdot n}{D \cdot n}
 
         where :math:`t` is the distance from the ray origin to the intersection point, 
         :math:`Q` is a point on the plane and :math:`n` the **outward** facing surface 
@@ -225,34 +225,34 @@ def ray_z_cylinder(length, radius, ray_origin, ray_direction):
 
             t_{\\text{bot}} = 
             \\frac{
-            \\left(
+            \left(
                 \\begin{bmatrix}
                 0 \\
                 0 \\
                 -0.5 L \\ 
-                \\end{bmatrix} -
+                \end{bmatrix} -
             \\begin{bmatrix}
                 x_E \\
                 y_E \\
                 z_E \\ 
-            \\end{bmatrix}
-            \\right) \\cdot
+            \end{bmatrix}
+            \\right) \cdot
             \\begin{bmatrix}
                 0 \\
                 0 \\
                 -1 \\ 
-            \\end{bmatrix}
+            \end{bmatrix}
             }{
             \\begin{bmatrix}
                 x_D \\
                 y_D \\
                 z_D \\ 
-            \\end{bmatrix} \\cdot
+            \end{bmatrix} \cdot
             \\begin{bmatrix}
                 0 \\
                 0 \\
                 -1 \\ 
-            \\end{bmatrix}
+            \end{bmatrix}
             }
 
         and for the top cap at :math:`z=L`,
@@ -260,34 +260,34 @@ def ray_z_cylinder(length, radius, ray_origin, ray_direction):
         .. math::
             t_{\\text{bot}} = 
             \\frac{
-            \\left(
+            \left(
                 \\begin{bmatrix}
                 0 \\
                 0 \\
                 0.5 L \\ 
-                \\end{bmatrix} -
+                \end{bmatrix} -
             \\begin{bmatrix}
                 x_E \\
                 y_E \\
                 z_E \\ 
-            \\end{bmatrix}
-            \\right) \\cdot
+            \end{bmatrix}
+            \\right) \cdot
             \\begin{bmatrix}
                 0 \\
                 0 \\
                 1 \\ 
-            \\end{bmatrix}
+            \end{bmatrix}
             }{
             \\begin{bmatrix}
                 x_D \\
                 y_D \\
                 z_D \\ 
-            \\end{bmatrix} \\cdot
+            \end{bmatrix} \cdot
             \\begin{bmatrix}
                 0 \\
                 0 \\
                 1 \\ 
-            \\end{bmatrix}
+            \end{bmatrix}
             }
     
 

--- a/pvtrace/material/component.py
+++ b/pvtrace/material/component.py
@@ -107,7 +107,7 @@ class Scatterer(Component):
         self._coefficient = coefficient
         if coefficient is None:
             raise ValueError("Coefficient must be specified.")
-        elif isinstance(coefficient, (float, np.float)):
+        elif isinstance(coefficient, float):
             self._abs_dist = Distribution(x=None, y=coefficient, hist=hist)
         elif isinstance(coefficient, np.ndarray):
             self._abs_dist = Distribution(

--- a/pvtrace/material/distribution.py
+++ b/pvtrace/material/distribution.py
@@ -29,7 +29,7 @@ class Distribution(object):
                 If x is not ascending or if any element of y is not finite.
         """
         self.hist = hist
-        if x is None and isinstance(y, (float, np.float)):
+        if x is None and isinstance(y, float):
             self._x = None
             self._y = y
         else:
@@ -46,13 +46,16 @@ class Distribution(object):
             self._x = x
             self._y = y
             if hist:
-                cdf = np.cumsum(y, dtype=np.float)
+                cdf = np.cumsum(y, dtype=float)
                 cdf *= 1.0 / cdf[-1]
                 self._cdf = cdf
                 self._edges = np.insert(x, x.size, 2 * x[-1] - x[-2])
             else:
                 cdf = np.cumsum((y[:-1] + y[1:]) * 0.5)
-                cdf = cdf / np.max(cdf)
+                try:
+                    cdf = cdf / np.max(cdf)
+                except FloatingPointError:
+                    breakpoint()
                 cdf = np.hstack([0.0, cdf])
                 self._cdf = cdf
 
@@ -70,7 +73,7 @@ class Distribution(object):
             ValueError
                 If x is outside the data range.
         """
-        if self._x is None and isinstance(self._y, (float, np.float)):
+        if self._x is None and isinstance(self._y, float):
             if isinstance(x, (list, tuple, np.ndarray)):
                 return np.zeros(len(x)) + self._y
             else:

--- a/pvtrace/material/distribution.py
+++ b/pvtrace/material/distribution.py
@@ -52,10 +52,7 @@ class Distribution(object):
                 self._edges = np.insert(x, x.size, 2 * x[-1] - x[-2])
             else:
                 cdf = np.cumsum((y[:-1] + y[1:]) * 0.5)
-                try:
-                    cdf = cdf / np.max(cdf)
-                except FloatingPointError:
-                    breakpoint()
+                cdf = cdf / np.max(cdf)
                 cdf = np.hstack([0.0, cdf])
                 self._cdf = cdf
 

--- a/pvtrace/material/surface.py
+++ b/pvtrace/material/surface.py
@@ -232,7 +232,7 @@ class Surface(BaseSurface):
         """ Returns `True` is the ray is reflected.
         """
         r = self.delegate.reflectivity(self, ray, geometry, container, adjacent)
-        if not isinstance(r, (int, float, np.float, np.int)):
+        if not isinstance(r, (int, float)):
             raise ValueError("Reflectivity must be a number.")
         if r == 0.0:
             return False

--- a/pvtrace/scene/scene.py
+++ b/pvtrace/scene/scene.py
@@ -97,7 +97,7 @@ class Scene(object):
         self.root = root
 
     def finalise_nodes(self):
-        """Update bounding boxes of node hierarchy in prepration for tracing."""
+        """Update bounding boxes of node hierarchy in preparation for tracing."""
         root = self.root
         if root is not None:
 
@@ -118,30 +118,25 @@ class Scene(object):
                         break
 
     @property
-    def light_nodes(self) -> Sequence[Light]:
+    def light_nodes(self) -> Sequence[Node]:
         """Returns all lights in the scene."""
-        root = self.root
-        found_nodes = []
-        for node in LevelOrderIter(root):
-            if isinstance(node.light, Light):
-                found_nodes.append(node)
-        return found_nodes
+        return [node for node in LevelOrderIter(self.root) if isinstance(node.light, Light)]
 
     @property
     def component_nodes(self) -> Sequence[Component]:
-        """Returns all lights in the scene."""
+        """Returns all the components present in the scene."""
         root = self.root
-        found_nodes = []
+        component = []
         for node in LevelOrderIter(root):
             if node.geometry:
                 if node.geometry.material:
-                    found_nodes.extend(node.geometry.material.components)
-        return found_nodes
+                    component.extend(node.geometry.material.components)
+        return component
 
-    def emit(self, num_rays):
+    def emit(self, num_rays: int):
         """Rays are emitted in the coordinate system of the world node.
 
-        Internally the scene cycles through Light nodes, askes them to emit
+        Internally the scene cycles through Light nodes, asks them to emit
         a ray and the converts the ray to the world coordinate system.
         """
         lights = self.light_nodes

--- a/pvtrace/scene/scene.py
+++ b/pvtrace/scene/scene.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
+import multiprocessing
 import os
-from concurrent.futures import ProcessPoolExecutor
 from typing import Optional, Sequence, Tuple
 from anytree import PostOrderIter, LevelOrderIter
 from pvtrace.scene.node import Node
 from pvtrace.light.light import Light
 from pvtrace.light.event import Event
 from pvtrace.material.component import Component
-from pvtrace.geometry.utils import intersection_point_is_ahead
+from pvtrace.geometry.utils import (
+    distance_between,
+    close_to_zero,
+    intersection_point_is_ahead,
+)
 from pvtrace.algorithm import photon_tracer
 import numpy as np
 import logging
@@ -53,6 +57,36 @@ def is_end_ray(event, metadata):
         elif metadata["hit"] == metadata["container"] and event == Event.TRANSMIT:
             return True  # escaped node
     return False
+
+
+def do_simulation_add_to_queue(scene, num_rays, seed, queue, end_rays):
+    """Worker function for multiple processing puts results into queue."""
+    # Re-seed for this thread/process
+    if seed is not None:
+        np.random.seed(seed)
+
+    count = 0
+    pid = os.getpid()
+
+    # What is an "end ray"?
+    # Only record major ray events should as entering/reflecting from nodes
+    # or being absorbed by reactor or non-radiatively. This option speeds
+    # up raytracing and allows full ray statistics on surfaces to be known.
+    # However, the full ray history is lost. Re-absorption events, and
+    # internal proagation details inside nodes are lost. The only details
+    # that remain from internal propagation is the total path length travelled
+    # and the duration it took.
+
+    for idx, ray in enumerate(scene.emit(num_rays)):
+        count = count + 1
+        for info in photon_tracer.step_forward(scene, ray):
+            ray, event, metadata = info
+            if end_rays:
+                if is_end_ray(event, metadata):
+                    queue.put((pid, idx, ray, event, metadata))
+            else:
+                queue.put((pid, idx, ray, event, metadata))
+    return pid
 
 
 class Scene(object):
@@ -159,7 +193,9 @@ class Scene(object):
         self,
         num_rays: int,
         workers: Optional[int] = None,
-        seed: Optional[int] = None
+        seed: Optional[int] = None,
+        queue: Optional[multiprocessing.Queue] = None,
+        end_rays: Optional[bool] = False,
     ):
         """Concurrently emit rays from light sources and return results.
 
@@ -171,6 +207,11 @@ class Scene(object):
             The number of sub-processes to use for raytracing. None will set to maximum value.
         seed: (Optional) int
             Only to be used for debugging to get reproducible ray sequence.
+        queue: (Optional) multiprocessing.Queue
+            If queue is specified results are delivered to the queue _instead_ of returning
+            results at the end of the simulation. This helps with reducing memory usage.
+        end_rays: (Optional) bool
+            Default if False being that all events are sent to the queue.
 
         Returns
         -------
@@ -190,11 +231,17 @@ class Scene(object):
         You must also set workers to one during debugging.
         """
         if workers is None:
-            workers = max(1, os.cpu_count() - 1)
+            workers = max(1, multiprocessing.cpu_count() - 1)
+
+        if workers == 1:
+            if queue:
+                return do_simulation_add_to_queue(self, num_rays, seed, queue, end_rays)
+            return do_simulation(self, num_rays, seed)
 
         num_rays_per_worker = num_rays // workers
-        # Single thread if workers=1 or less than 1 photons/workers
-        if workers == 1 or num_rays_per_worker == 0:
+        if num_rays_per_worker == 0:
+            if queue:
+                return do_simulation_add_to_queue(self, num_rays, seed, queue, end_rays)
             return do_simulation(self, num_rays, seed)
 
         if num_rays_per_worker * workers < num_rays:
@@ -214,14 +261,28 @@ class Scene(object):
                 "Seed must be None to ensure different quasi-random sequences in each process"
             )
 
+        pool = multiprocessing.Pool(processes=workers)
+
+        # Results are send to queue
+        if queue:
+            results_proxy = [
+                pool.apply_async(
+                    do_simulation_add_to_queue,
+                    (self, rays[idx], seeds[idx], queue, end_rays),
+                )
+                for idx in range(workers)
+            ]
+            [result.get() for result in results_proxy]
+            return
+
+        # Results are processed directly and returned
+        results_proxy = [
+            pool.apply_async(do_simulation, (self, rays[idx], seeds[idx]))
+            for idx in range(workers)
+        ]
         results = []
-
-        with ProcessPoolExecutor(workers) as pool:
-            # ProcessPoolExecutor has an internal queue
-            results_proxy = pool.map(do_simulation, [self] * workers, rays, seeds)
-
-            for result in results_proxy:
-                for history in result:
-                    results.append(history)
-
+        for result in results_proxy:
+            histories = result.get()
+            for history in histories:
+                results.append(history)
         return results


### PR DESCRIPTION
The use of np.float and np.int is deprecated (see [numpy docs ](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations))