### PR TITLE
Enable support for Py3.8 and 3.9

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.7"]
+        python-version: ["3.7", "3.8", "3.9"]
 
     steps:
       - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 anytree
-meshcat>=0.0.16
+meshcat>=0.1.1
 numpy
 pandas
 trimesh[easy]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 anytree
-meshcat>=0.0.16
+meshcat>=0.1.1
 numpy
 trimesh[easy]
 jupyter

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         __version__
     ),
     entry_points={"console_scripts": ["pvtrace-cli=pvtrace.cli.main:main"]},
-    python_requires=">=3.7.2,<3.8",
+    python_requires=">=3.7.2,<3.10",
     packages=find_packages(),
     keywords=["optics", "raytracing", "photovoltaics", "energy"],
     install_requires=["numpy", "pandas", "anytree", "meshcat>=0.0.16", "trimesh[easy]"],

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     python_requires=">=3.7.2,<3.10",
     packages=find_packages(),
     keywords=["optics", "raytracing", "photovoltaics", "energy"],
-    install_requires=["numpy", "pandas", "anytree", "meshcat>=0.0.16", "trimesh[easy]"],
+    install_requires=["numpy", "pandas", "anytree", "meshcat>=0.1.1", "trimesh[easy]"],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,7 @@ setup(
         "Topic :: Scientific/Engineering :: Visualization",
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )


### PR DESCRIPTION
Passes CI 3.7/3.8/3.9 linux/mac/win, personally tested 3.9.4 on Windows and 3.7.9, 3.8.5 3.9.1 on Linux.

Enabled by upstream fix rdeits/meshcat-python#78 released as 0.1.0 and probably other upstream changes